### PR TITLE
Supports installation commands like `vfox install java@26.ea.1-graal`

### DIFF
--- a/hooks/pre_install.lua
+++ b/hooks/pre_install.lua
@@ -33,6 +33,9 @@ function PLUGIN:PreInstall(ctx)
     end
     
     local jdk = filtered_jdks[1]
+    if not jdk.links or not jdk.links.pkg_info_uri then
+        error("Invalid JDK package info: missing download links for " .. ctx.version)
+    end
     local info = json.decode(httpGet(jdk.links.pkg_info_uri, "Failed to fetch jdk info")).result[1]
     -- TODO: checksum
     -- local checksum = info.checksum

--- a/lib/distribution_version.lua
+++ b/lib/distribution_version.lua
@@ -55,6 +55,27 @@ function distribution_version.parse_distribution (name)
 end
 
 
+--- Converts user-input version format to Foojay API format
+--- Examples: "26.ea.1" -> "26-ea+1", "26.ea" -> "26-ea", "25.0.3" -> "25.0.3"
+--- @param version string User-input version
+--- @return string Converted version for Foojay API
+function distribution_version.convert_version_for_api(version)
+    -- Handle EA version format: "X.ea.Y" -> "X-ea+Y"
+    local ea_version, ea_build = version:match("^(%d+)%.ea%.(%d+)$")
+    if ea_version and ea_build then
+        return ea_version .. "-ea+" .. ea_build
+    end
+    
+    -- Handle EA version format without build number: "X.ea" -> "X-ea"
+    local ea_version_only = version:match("^(%d+)%.ea$")
+    if ea_version_only then
+        return ea_version_only .. "-ea"
+    end
+    
+    -- Return as-is for normal versions
+    return version
+end
+
 function distribution_version.parse_version (arg)
     local version_parts = strings.split(arg, "-")
     local version
@@ -93,6 +114,9 @@ function distribution_version.parse_version (arg)
             end
         end
     end
+
+    -- Convert version format for Foojay API
+    version = distribution_version.convert_version_for_api(version)
 
     return {
         version = version,

--- a/lib/foojay.lua
+++ b/lib/foojay.lua
@@ -4,7 +4,7 @@ local json = require("json")
 local foojay = {}
 
 local URL =
-"https://api.foojay.io/disco/v3.0/packages/jdks?version=%s&distribution=%s&architecture=%s&archive_type=%s&operating_system=%s&lib_c_type=%s&release_status=ga&directly_downloadable=true"
+"https://api.foojay.io/disco/v3.0/packages/jdks?version=%s&distribution=%s&architecture=%s&archive_type=%s&operating_system=%s&lib_c_type=%s&directly_downloadable=true"
 
 --- Detects the libc type on Linux systems (glibc or musl)
 --- @return string "glibc" or "musl"


### PR DESCRIPTION
- Fixes https://github.com/version-fox/vfox-java/issues/29 .
- Supports installation commands like `vfox install java@26.ea.1-graal`.
- Honestly, I don't know where to put the unit tests.